### PR TITLE
Add simple Express backend example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The Spec Builder bridges the gap between domain expertise and technical implemen
 3. The app will generate a clear specification based on your inputs
 4. Use the generated specification as input for AI-assisted development tools
 
+## Running the Backend
+
+1. Navigate to the `backend` folder
+2. Run `npm install` to install dependencies
+3. Start the server with `npm start` (or `node server.js`)
+
 ## Inspiration
 
 This project is inspired by Sean Grove's vision of the future of coding, where domain experts can focus on what they know best while AI handles the technical implementation. The app aims to make this vision a reality by helping domain experts articulate their requirements clearly and systematically.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "spec-builder-backend",
+  "version": "1.0.0",
+  "description": "Simple Express backend example",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+
+app.post('/api/build', (req, res) => {
+  res.json({ success: true });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add `.gitignore`
- create `backend` folder with Express server
- document how to run the backend in README

## Testing
- `npm install --silent` *(fails: nothing to install)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68756618477883338c825eb510a7bd55